### PR TITLE
#3 Added config params for in and out directories. Removed deviceloca…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 2.0.0
+
+- Now its possible to set in and out directories for files.
+- You can set the pattern by which to search for files.
+- Generated keys can be switched to another case in generated classes.
+- Removed dependency on devicelocale.
+- Configs with baseLocale and maps moved from config.i18.json to build.yaml
+- Generators replaced with fields for keys with static values.
+- Arguments now can be wrapped with braces like ${key}.
+
+Example of new config in build.yaml:
+```yaml
+targets:
+  $default:
+    builders:
+      fast_i18n:i18nBuilder:
+        options:
+          directory_in: assets/locale
+          directory_out: lib/i18n
+          files_pattern: '.json'
+          base_locale: en
+          key_case: snake
+          maps:
+            - 'a'
+            - 'b'
+            - 'c.d'
+```
+
 ## 1.8.2
 
 - Hotfix: possible NPE when calling Translations.of(context)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lightweight i18n solution. Use JSON files to create typesafe translations.
 
 ```yaml
 dependencies:
-  fast_i18n: ^1.8.2
+  fast_i18n: ^2.0.0
 
 dev_dependencies:
   build_runner: any

--- a/build.yaml
+++ b/build.yaml
@@ -1,9 +1,8 @@
 # https://pub.dartlang.org/packages/build_config
 builders:
-
   i18nBuilder:
-    import: "package:fast_i18n/builder.dart"
-    builder_factories: ["i18nBuilder"]
-    build_extensions: {".i18n.json": [".g.dart"]}
+    import: 'package:fast_i18n/builder.dart'
+    builder_factories: ['i18nBuilder']
+    build_extensions: {'.i18n.json': ['.g.dart']}
     build_to: source
     auto_apply: root_package

--- a/example/README.md
+++ b/example/README.md
@@ -4,7 +4,7 @@
 
 ```yaml
 dependencies:
-  fast_i18n: ^1.8.2
+  fast_i18n: ^2.0.0
 
 dev_dependencies:
   build_runner: any

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:io';
+
 import 'package:build/build.dart';
 import 'package:fast_i18n/src/generator.dart';
 import 'package:fast_i18n/src/model.dart';
@@ -6,15 +8,32 @@ import 'package:fast_i18n/src/parser_json.dart';
 import 'package:fast_i18n/utils.dart';
 import 'package:glob/glob.dart';
 
-Builder i18nBuilder(BuilderOptions options) => I18nBuilder();
+Builder i18nBuilder(BuilderOptions options) => I18nBuilder(options);
 
 class I18nBuilder implements Builder {
+  I18nBuilder(this.options);
+
+  static const String defaultFilePattern = '.i18n.json';
+
+  final BuilderOptions options;
+
   bool _generated = false;
+
+  String get filesPattern => options.config['files_pattern'] ?? defaultFilePattern;
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-    if (buildStep.inputId.pathSegments.last == 'config.i18n.json' ||
-        buildStep.inputId.pathSegments.last.indexOf('_') != -1) return;
+    String directoryInPath = options.config['directory_in'];
+    String baseLocale = options.config['base_locale'];
+    List<String> maps = options.config['maps'];
+    String directoryOutPath = options.config['directory_out'];
+    String keyCase = options.config['key_case'];
+
+    I18nConfig config = I18nConfig(baseLocale ?? '', maps ?? []);
+
+    if (null != directoryInPath && !buildStep.inputId.path.contains(directoryInPath)) {
+      return;
+    }
 
     // only generate once
     if (!_generated) {
@@ -22,42 +41,39 @@ class I18nBuilder implements Builder {
 
       // detect all locales, their assetId and the baseName
       Map<AssetId, String> locales = Map();
-      String baseName;
-      AssetId configAsset;
-      await buildStep.findAssets(Glob('**.i18n.json')).forEach((assetId) {
-        String fileNameNoExtension =
-            assetId.pathSegments.last.replaceAll('.i18n.json', '');
+      String baseName = 'strings';
 
-        if (fileNameNoExtension == 'config') {
-          configAsset = assetId;
-        } else {
-          RegExpMatch match = Utils.localeRegex.firstMatch(fileNameNoExtension);
-          if (match != null) {
-            String language = match.group(1);
-            String country = match.group(3);
+      final Glob findAssetsPattern = null != directoryInPath
+          ? Glob('**$directoryInPath/*$filesPattern')
+          : Glob('**$filesPattern');
 
-            if (country != null)
-              locales[assetId] = language + '-' + country.toLowerCase();
-            else
-              locales[assetId] = language;
-          } else {
-            locales[assetId] = '';
-            baseName = fileNameNoExtension;
+      await buildStep.findAssets(findAssetsPattern).forEach((assetId) {
+        String fileNameNoExtension = assetId.pathSegments.last.replaceAll(filesPattern, '');
+
+        RegExpMatch match = Utils.localeRegex.firstMatch(fileNameNoExtension);
+
+        if (match != null) {
+          if (null != match.group(2)) {
+            baseName = match.group(2);
           }
+
+          String language = match.group(3);
+          String country = match.group(5);
+
+          if (country != null) {
+            locales[assetId] = language + '-' + country.toLowerCase();
+          } else {
+            locales[assetId] = language;
+          }
+        } else {
+          locales[assetId] = '';
+          baseName = fileNameNoExtension;
         }
       });
 
-      I18nConfig config;
-      if (configAsset != null) {
-        String content = await buildStep.readAsString(configAsset);
-        config = parseConfig(content);
-      } else {
-        // default config
-        config = I18nConfig('', []);
-      }
-
       // map each assetId to I18nData
       Map<AssetId, I18nData> localesWithData = Map();
+
       for (AssetId assetId in locales.keys) {
         String locale = locales[assetId];
         if (locale == '') locale = config.baseLocale;
@@ -68,21 +84,29 @@ class I18nBuilder implements Builder {
       }
 
       // generate
-      String output = generate(localesWithData.values.toList()
-        ..sort((a, b) => a.locale.compareTo(b.locale)));
+      String output = generate(
+        localesWithData.values.toList()
+          ..sort((a, b) => a.locale.compareTo(b.locale)),
+        keyCase,
+      );
 
       // write only to main locale
       AssetId baseId = localesWithData.entries
           .firstWhere((element) => element.value.base)
           .key;
-      AssetId newId = AssetId(
-          baseId.package, baseId.path.replaceAll('.i18n.json', '.g.dart'));
-      await buildStep.writeAsString(newId, output);
+
+      if (null == directoryOutPath) {
+        directoryOutPath = (baseId.pathSegments..removeLast()).join('/');
+      }
+
+      final String outFilePath = '$directoryOutPath/$baseName.g.dart';
+
+      File(outFilePath).writeAsStringSync(output);
     }
   }
 
   @override
-  final buildExtensions = const {
-    '.i18n.json': ['.g.dart']
+  get buildExtensions => {
+    filesPattern: ['.g.dart'],
   };
 }

--- a/lib/fast_i18n.dart
+++ b/lib/fast_i18n.dart
@@ -1,7 +1,7 @@
 library fast_i18n;
 
-import 'package:devicelocale/devicelocale.dart';
 import 'package:fast_i18n/utils.dart';
+import 'package:flutter/widgets.dart';
 
 class FastI18n {
   /// returns the locale string used by the device
@@ -9,7 +9,7 @@ class FastI18n {
   /// fallback to '' (default locale)
   static Future<String> findDeviceLocale(List<String> supported,
       [String baseLocale = '']) async {
-    String deviceLocale = (await Devicelocale.currentAsLocale).toLanguageTag();
+    String deviceLocale = WidgetsBinding.instance.window.locale.languageCode;
 
     return selectLocale(deviceLocale, supported, baseLocale);
   }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -78,23 +78,11 @@ class TextNode extends Value {
 /// 'hello $name' => ['name']
 /// 'hello \$name => []
 /// 'my name is $name and I am $age years old' => ['name', 'age']
+/// 'my name is ${name} and I am ${age} years old' => ['name', 'age']
 List<String> _findArguments(String content) {
-  String s = content.replaceAll('\\\$', ''); // remove \$
-  List<String> arguments = [];
-  int indexStart = s.indexOf('\$');
-  while (indexStart != -1) {
-    if (indexStart == s.length - 1) break;
-
-    int indexEnd = s.indexOf(Utils.specialRegex, indexStart + 1);
-    if (indexEnd != -1) {
-      arguments.add(s.substring(indexStart + 1, indexEnd));
-      s = s.substring(indexEnd);
-      indexStart = s.indexOf('\$');
-    } else {
-      arguments.add(s.substring(indexStart + 1));
-      break;
-    }
-  }
-
-  return arguments;
+  return Utils
+      .argumentsRegex
+      .allMatches(content)
+      .map((e) => e.group(2))
+      .toList();
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,10 +1,12 @@
 class Utils {
+  static RegExp argumentsRegex = RegExp(r'([^\\]|^)\$\{?(\w+)\}?');
+
   /// check if special character exists
   static RegExp specialRegex = RegExp(r'[^a-zA-Z0-9]');
 
   /// finds the parts of the locale
   /// must start with an underscore
-  static RegExp localeRegex = RegExp(r'_([a-z]{2})([-_]([a-zA-Z]{2}))?$');
+  static RegExp localeRegex = RegExp(r'^((\w+)_)?([a-z]{2})([-_]([a-zA-Z]{2}))?$');
 
   /// returns the locale with the following syntax:
   /// - all lowercase

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,13 +169,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.8+1"
-  devicelocale:
-    dependency: "direct main"
-    description:
-      name: devicelocale
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.3"
   fake_async:
     dependency: transitive
     description:
@@ -354,6 +347,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  recase:
+    dependency: "direct main"
+    description:
+      name: recase
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   shelf:
     dependency: transitive
     description:
@@ -522,4 +522,3 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.12.13+hotfix.6 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fast_i18n
 description: Lightweight i18n solution. Use JSON files to create typesafe translations.
-version: 1.8.2
+version: 2.0.0
 homepage: https://github.com/Tienisto/flutter-fast-i18n
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   build: ^1.5.0
   glob: ^1.2.0
-  devicelocale: ^0.3.3
+  recase: 3.0.0
 
 dev_dependencies:
   build_runner: any


### PR DESCRIPTION
## 2.0.0

- Now its possible to set in and out directories for files.
- You can set the pattern by which to search for files.
- Generated keys can be switched to another case in generated classes.
- Removed dependency on devicelocale.
- Configs with baseLocale and maps moved from config.i18.json to build.yaml
- Generators replaced with fields for keys with static values.
- Arguments now can be wrapped with braces like ${key}.

Example of new config in build.yaml:
```yaml
targets:
  $default:
    builders:
      fast_i18n:i18nBuilder:
        options:
          directory_in: assets/locale
          directory_out: lib/i18n
          files_pattern: '.json'
          base_locale: en
          key_case: snake
          maps:
            - 'a'
            - 'b'
            - 'c.d'