### PR TITLE
Use '$baseClassName' instead of 'Strings' as field type in 'InheritedLocaleData' widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- Fix compilation error occurring when non-standard name (not 'strings.i18n.json') is used for json files.
+
 ## 2.2.0
 
 - new config: `output_translate_var`, renames default `t` variable

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lightweight i18n solution. Use JSON files to create typesafe translations.
 
 ```yaml
 dependencies:
-  fast_i18n: ^2.2.0
+  fast_i18n: ^2.2.1
 
 dev_dependencies:
   build_runner: any

--- a/example/README.md
+++ b/example/README.md
@@ -4,7 +4,7 @@
 
 ```yaml
 dependencies:
-  fast_i18n: ^2.2.0
+  fast_i18n: ^2.2.1
 
 dev_dependencies:
   build_runner: any

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -190,7 +190,7 @@ void _generateHeader(StringBuffer buffer, I18nConfig config, List<I18nData> allL
   // InheritedLocaleData
   buffer.writeln();
   buffer.writeln('class $inheritedClass extends InheritedWidget {');
-  buffer.writeln('\tfinal Strings translations;');
+  buffer.writeln('\tfinal $baseClassName translations;');
   buffer.writeln('\t$inheritedClass({this.translations, Widget child}) : super(child: child);');
   buffer.writeln();
   buffer.writeln('\t@override');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fast_i18n
 description: Lightweight i18n solution. Use JSON files to create typesafe translations.
-version: 2.2.0
+version: 2.2.1
 homepage: https://github.com/Tienisto/flutter-fast-i18n
 
 environment:


### PR DESCRIPTION
This change fixes the compilation problem which was occurring if a non 'strings' name was used for the json file.

Here are the screenshot of how the problem looked like:

<img width="307" alt="image" src="https://user-images.githubusercontent.com/8143332/109428907-35742d80-7a0a-11eb-94fb-012ed901d587.png">
<img width="485" alt="image" src="https://user-images.githubusercontent.com/8143332/109428923-49b82a80-7a0a-11eb-8cad-445193a057ac.png">
<img width="690" alt="image" src="https://user-images.githubusercontent.com/8143332/109428930-4d4bb180-7a0a-11eb-981e-49548a3f8af2.png">
<img width="651" alt="image" src="https://user-images.githubusercontent.com/8143332/109429159-6739c400-7a0b-11eb-9ede-5d194415ceb5.png">

