### PR TITLE
Make locales case sensitive to comply with `MaterialApp`'s `supportedLocales`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+- Make locales case sensitive to comply with `MaterialApp`'s `supportedLocales`.
+
 ## 2.3.0
 
 - Add `supportedLocales` property that can be used to fill `MaterialApp`'s `supportedLocales` argument.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lightweight i18n solution. Use JSON files to create typesafe translations.
 
 ```yaml
 dependencies:
-  fast_i18n: ^2.3.0
+  fast_i18n: ^2.3.1
 
 dev_dependencies:
   build_runner: any

--- a/example/README.md
+++ b/example/README.md
@@ -4,7 +4,7 @@
 
 ```yaml
 dependencies:
-  fast_i18n: ^2.3.0
+  fast_i18n: ^2.3.1
 
 dev_dependencies:
   build_runner: any

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -69,9 +69,9 @@ class I18nBuilder implements Builder {
         final country = match.group(5);
 
         if (country != null) {
-          locales[assetId] = (language + '-' + country).toLowerCase();
+          locales[assetId] = '$language-$country';
         } else {
-          locales[assetId] = language.toLowerCase();
+          locales[assetId] = language;
         }
       } else {
         locales[assetId] = baseLocale;

--- a/lib/fast_i18n.dart
+++ b/lib/fast_i18n.dart
@@ -13,6 +13,7 @@ class FastI18n {
 
   /// Returns the candidate (or part of it) if it is supported.
   /// Fallbacks to base locale.
+  /// Please note that locales are case sensitive.
   static String selectLocale(
       String candidate, List<String> supported, String baseLocale) {
     // normalize
@@ -25,14 +26,9 @@ class FastI18n {
 
     // 2nd try: match the first part (language)
     List<String> deviceLocaleParts = candidate.split(_localePartsDelimiter);
+    String deviceLocaleLanguage = deviceLocaleParts.first;
     selected = supported.firstWhere(
-        (element) => element == deviceLocaleParts.first,
-        orElse: () => null);
-    if (selected != null) return selected;
-
-    // 3rd try: match the second part (region)
-    selected = supported.firstWhere(
-        (element) => element == deviceLocaleParts.last,
+        (element) => element.startsWith(deviceLocaleLanguage),
         orElse: () => null);
     if (selected != null) return selected;
 

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -124,6 +124,7 @@ void _generateHeader(
   buffer.writeln();
   buffer.writeln('\t/// Uses locale of the device, fallbacks to base locale.');
   buffer.writeln('\t/// Returns the locale which has been set.');
+  buffer.writeln('\t/// Be aware that the locales are case sensitive.');
   buffer.writeln('\tstatic String useDeviceLocale() {');
   buffer.writeln('\t\tString deviceLocale = FastI18n.getDeviceLocale();');
   buffer.writeln('\t\treturn setLocale(deviceLocale);');
@@ -132,6 +133,7 @@ void _generateHeader(
   buffer.writeln();
   buffer.writeln('\t/// Sets locale, fallbacks to base locale.');
   buffer.writeln('\t/// Returns the locale which has been set.');
+  buffer.writeln('\t/// Be aware that the locales are case sensitive.');
   buffer.writeln('\tstatic String setLocale(String locale) {');
   buffer.writeln(
       '\t\t$localeVar = FastI18n.selectLocale(locale, $mapVar.keys.toList(), $baseLocaleVar);');

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,15 +1,13 @@
 class Utils {
   static RegExp argumentsRegex = RegExp(r'([^\\]|^)\$\{?(\w+)\}?');
 
-  /// finds the parts of the locale
-  /// must start with an underscore
+  /// Finds the parts of the locale. It must start with an underscore.
   static RegExp localeRegex =
       RegExp(r'^((\w+)_)?([a-z]{2})([-_]([a-zA-Z]{2}))?$');
 
-  /// returns the locale with the following syntax:
-  /// - all lowercase
+  /// Returns the locale with the following syntax:
   /// - dash as separator
   static String normalize(String locale) {
-    return locale.toLowerCase().replaceAll('_', '-');
+    return locale.replaceAll('_', '-');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fast_i18n
 description: Lightweight i18n solution. Use JSON files to create typesafe translations.
-version: 2.3.0
+version: 2.3.1
 homepage: https://github.com/Tienisto/flutter-fast-i18n
 
 environment:

--- a/test/fast_i18n_test.dart
+++ b/test/fast_i18n_test.dart
@@ -16,19 +16,15 @@ void testSelectLocale() {
     });
 
     test('match exactly but need normalizing', () {
-      expect(FastI18n.selectLocale('en_US', ['en-us', 'de-de'], ''), 'en-us');
+      expect(FastI18n.selectLocale('en_US', ['en-US', 'de-DE'], ''), 'en-US');
     });
 
-    test('match first part', () {
+    test('match first part (language)', () {
       expect(FastI18n.selectLocale('de_DE', ['en', 'de'], ''), 'de');
     });
 
-    test('prefer first part over second part', () {
+    test('prefer first part (language) over second part (country)', () {
       expect(FastI18n.selectLocale('en_DE', ['de', 'en'], ''), 'en');
-    });
-
-    test('match last part', () {
-      expect(FastI18n.selectLocale('en_US', ['us', 'de'], ''), 'us');
     });
 
     test('fallback', () {

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -44,15 +44,15 @@ void testNormalize() {
     });
 
     test('en_US', () {
-      expect(Utils.normalize('en_US'), 'en-us');
+      expect(Utils.normalize('en_US'), 'en-US');
     });
 
     test('en-US', () {
-      expect(Utils.normalize('en-US'), 'en-us');
+      expect(Utils.normalize('en-US'), 'en-US');
     });
 
     test('enUS', () {
-      expect(Utils.normalize('enUS'), 'enus');
+      expect(Utils.normalize('enUS'), 'enUS');
     });
   });
 }


### PR DESCRIPTION
It was needed to avoid this type of error thrown from MaterialApp:
<img width="741" alt="image" src="https://user-images.githubusercontent.com/8143332/109781175-bc96f080-7c18-11eb-861a-d39134d178ac.png">
